### PR TITLE
Updated CI job to automatically create a new release when a tag is created

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -25,7 +25,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
     
-    - name: Build with Ant and package
+    - name: Build with Ant
       run: |
         wget -q https://downloads.dataiku.com/public/studio/$DSS_VERSION/dataiku-dss-$DSS_VERSION.tar.gz
         tar -zxf dataiku-dss-$DSS_VERSION.tar.gz  dataiku-dss-$DSS_VERSION/dist
@@ -33,13 +33,17 @@ jobs:
         export DKUINSTALLDIR=$(pwd)/dataiku-dss-$DSS_VERSION
         ant -noinput -buildfile build.xml
         rm -Rf dataiku-dss* java-build/
-        zip -r dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip ./ -x "*/.*" -x ".*"
     
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         name: dss-plugin-elasticsearch-index-template
-        path: dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip
+        path: ./
+    
+    - name: Package plugin before release
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        zip -r dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip ./ -x "*/.*" -x ".*"
     
     - name: Create release and publish package
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -52,4 +52,4 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip
+        files: dss-plugin-elasticsearch-index-template-*.zip

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  tags:
+      - '*'
 
 
 env:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -11,28 +11,38 @@ on:
 
 
 env:
-  DSS_VERSION: 11.3.1
+  DSS_VERSION: 11.4.0
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
-    - name: Build with Ant
+    
+    - name: Build with Ant and package
       run: |
         wget -q https://downloads.dataiku.com/public/studio/$DSS_VERSION/dataiku-dss-$DSS_VERSION.tar.gz
         tar -zxf dataiku-dss-$DSS_VERSION.tar.gz  dataiku-dss-$DSS_VERSION/dist
         tar -zxf dataiku-dss-$DSS_VERSION.tar.gz  dataiku-dss-$DSS_VERSION/lib
         export DKUINSTALLDIR=$(pwd)/dataiku-dss-$DSS_VERSION
         ant -noinput -buildfile build.xml
-    - name: 'Upload Artifact'
+        rm -Rf dataiku-dss* java-build/
+        zip -r dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip ./ -x "*/.*" -x ".*"
+    
+    - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         name: dss-plugin-elasticsearch-index-template
-        path: java-lib/dss-plugin-elasticsearch-index-template.jar
-        retention-days: 5
+        path: dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip
+    
+    - name: Create release and publish package
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: dss-plugin-elasticsearch-index-template-$GITHUB_REF_NAME.zip

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -6,10 +6,11 @@ name: Java CI
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - '*'
   pull_request:
     branches: [ "master" ]
-  tags:
-      - '*'
+  
 
 
 env:


### PR DESCRIPTION
* Updated CI job to automatically create a new release when a tag is created
* Fixed artifact upload to upload the whole plugin and not only the builded JAR 
* Updated target DSS version to 11.4.0